### PR TITLE
Lower PHP version requirement for compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=8.0",
+    "php": ">=7.4",
     "symfony/framework-bundle": "^5.4|^6.4|^7.0",
     "symfony/console": "^5.0|^6.0|^7.0",
     "symfony/filesystem": "^5.0|^6.0|^7.0",


### PR DESCRIPTION
Adjust the PHP version requirement to support older environments, allowing for greater compatibility with legacy systems.