### PR TITLE
Lower PHP version requirement and update command definition for compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=8.0",
+    "php": ">=7.4",
     "symfony/framework-bundle": "^5.4|^6.4|^7.0",
     "symfony/console": "^5.0|^6.0|^7.0",
     "symfony/filesystem": "^5.0|^6.0|^7.0",

--- a/src/Command/InstallCastorCommand.php
+++ b/src/Command/InstallCastorCommand.php
@@ -2,7 +2,6 @@
 
 namespace TheDevOpser\CastorBundle\Command;
 
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -10,12 +9,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\KernelInterface;
 
-#[AsCommand(
-    name: 'castor:install',
-    description: 'Installe le fichier castor.php à la racine du projet'
-)]
 class InstallCastorCommand extends Command
 {
+    protected static $defaultName = 'castor:install';
+    protected static $defaultDescription = 'Installe le fichier castor.php à la racine du projet';
+
     private string $projectDir;
     private string $bundleDir;
     private Filesystem $filesystem;


### PR DESCRIPTION
Adjust the PHP version requirement to support older environments and replace attribute-based command definitions with static properties for improved compatibility.